### PR TITLE
Makemodule-local.am : help relative #include "helpers.h" find the needed file

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -3,7 +3,7 @@ AM_CXXFLAGS += -fvisibility=hidden
 
 ECPPC ?= ecppc
 ECPPFLAGS = --nolog
-ECPPFLAGS_CPP = -I$(top_builddir)/include -I$(top_srcdir)/include
+ECPPFLAGS_CPP = -I$(top_builddir)/include -I$(top_srcdir)/include -I$(top_builddir)/src -I$(top_srcdir)/src
 
 ECPPFILES= \
 	rest_document_DELETE.ecpp \


### PR DESCRIPTION
Help avoid FTY build errors like :

````
  CXX      src/src_libfty_asset_mapping_rest_la-rest_communication_PUT.lo
/home/travis/build/jimklimov/FTY/.srcclone/Linux-x86_64-czmq_4/fty-security-wallet-rest/src/rest_document_DELETE.ecpp:35:21: fatal error: helpers.h: No such file or directory
 #include "helpers.h"
                     ^
compilation terminated.
````