### PR TITLE
[WIP-CheckForRippleEffects] Problem: re-auth failure returns HTTP-500

### DIFF
--- a/src/rest_document_DELETE.ecpp
+++ b/src/rest_document_DELETE.ecpp
@@ -59,7 +59,7 @@ UserInfo user;
   //check re-auth
   if( !user.reauth())
   {
-    http_die ("internal-error", "Wrong confirmation password");
+    http_die ("not-authorized", "Wrong confirmation password");
   }
 
 

--- a/src/rest_document_PUT.ecpp
+++ b/src/rest_document_PUT.ecpp
@@ -56,7 +56,7 @@ UserInfo user;
   //check re-auth
   if( !user.reauth())
   {
-    http_die ("internal-error", "Wrong confirmation password");
+    http_die ("not-authorized", "Wrong confirmation password");
   }
 
   Path path(request.getPathInfo());

--- a/src/rest_documents_POST.ecpp
+++ b/src/rest_documents_POST.ecpp
@@ -57,7 +57,7 @@ UserInfo user;
   //check re-auth
   if( !user.reauth())
   {
-    http_die ("internal-error", "Wrong confirmation password");
+    http_die ("not-authorized", "Wrong confirmation password");
   }
 
   Path path(request.getPathInfo());


### PR DESCRIPTION
Solution: return HTTP-401 (auth error) instead

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: This change makes sense to me as a logical response to auth failures, saw too many 500's in CI test logs.

It could be argued the original error code was "security by obscurity" but that is not very safe anyway and more confusing than useful. Still, tagged as "question" so reviewers decide whether to merge this.